### PR TITLE
Added Discord to Minecraft nickname support.

### DIFF
--- a/src/main/java/chikachi/discord/listener/DiscordListener.java
+++ b/src/main/java/chikachi/discord/listener/DiscordListener.java
@@ -128,7 +128,7 @@ public class DiscordListener extends ListenerAdapter {
             );
 
             Message message = new Message()
-                .setAuthor(event.getAuthor().getName())
+                .setAuthor(event.getMember().getEffectiveName())
                 .setMessage(config.discord.channels.generic.messages.chatMessage)
                 .setArguments(arguments);
 


### PR DESCRIPTION
Uses getMember().getEffectiveName() rather than getAuthor().getName(). getEffectiveName uses the Discord user's nickname if they have one, regular user name if they don't.