### PR TITLE
Wait for tsc before running Forge

### DIFF
--- a/serverTest/package.json
+++ b/serverTest/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "start-dev": "tsc & node dist/index.js"
+    "start-dev": "tsc && node dist/index.js"
   },
   "version": "0.0.2",
   "dependencies": {


### PR DESCRIPTION
`&` runs commands in the background, `&&` checks if tsc finished successfully before continuing. I figure you wanted the latter.

Thanks for the CI runner, by the way.